### PR TITLE
Add type hints for functions in the utils directory

### DIFF
--- a/src/polus/utils/io.py
+++ b/src/polus/utils/io.py
@@ -6,7 +6,7 @@ from polus.config.user_inputs import read_atom_names
 from polus.files.inputs import GetInputBasename
 
 
-def GetRandInFile(InDir):
+def GetRandInFile(InDir: str) -> str:
     """
     This function reads a random file from the input Directory
     
@@ -23,7 +23,7 @@ def GetRandInFile(InDir):
         RaiseError(message="Cannot find input directory")
     return InFile
 
-def IsCSV(file_):
+def IsCSV(file_: str) -> bool:
     """
     This function checks if a file has comma separated content
     
@@ -32,7 +32,7 @@ def IsCSV(file_):
     """
     return file_.endswith(".csv")
 
-def get_FInFile_IO_Dirs(root,input_dir,output_dir):
+def get_FInFile_IO_Dirs(root: str, input_dir: str, output_dir: str) -> tuple[str, str, str, list[object] | None]:
     default_input_dir = os.path.join(root,"input_files")
     cmd_args          = read_cmd_args()
     config_details    = read_config()

--- a/src/polus/utils/logging.py
+++ b/src/polus/utils/logging.py
@@ -5,24 +5,24 @@ import logging
 global logger
 logger = logging.getLogger(__name__)
 
-def RaiseError(message):
+def RaiseError(message: str) -> None:
     if (isinstance(message,str)):
         logger.error(msg=message)
         sys.exit()
     else:
         InvalidLogMessage()
 
-def RaiseWarning(message):
+def RaiseWarning(message: str) -> None:
     if (isinstance(message,str)):
         logger.warning(msg=message)
     else:
         InvalidLogMessage()
 
-def PrintInfo(message):
+def PrintInfo(message: str) -> None:
     if (isinstance(message,str)):
         logger.info(msg=message)
     else:
         InvalidLogMessage()
 
-def InvalidLogMessage():
+def InvalidLogMessage() -> None:
     logger.warning(msg="Invalid logging message")

--- a/src/polus/utils/printing.py
+++ b/src/polus/utils/printing.py
@@ -10,7 +10,7 @@ from polus.utils.logging import RaiseError
 from polus.utils.read_module import check_input_files, read_job_details
 from datetime import datetime
 
-def PrintJobDetails():
+def PrintJobDetails() -> None:
     now       = datetime.now()
     date      = now. strftime("%A %d %B %Y")
     time      = now. strftime("%H:%M:%S")
@@ -35,7 +35,7 @@ def PrintJobDetails():
     #print("*"*82)
     #print(f"{'       Task'} {'Duration(s)':>70}")
 
-def PrintOnTerminal(msg=None,duration=None,msgLength=None):
+def PrintOnTerminal(msg: str | None = None, duration: float | None = None, msgLength: str | None = None) -> None:
     if isinstance(msg,str):
         print(f"POLUS: {msg}",end="")
     elif isinstance(duration,float) and isinstance(msgLength,int):
@@ -44,7 +44,7 @@ def PrintOnTerminal(msg=None,duration=None,msgLength=None):
     else:
         RaiseError(message=" Program cannot print information on standard output terminal ")
 
-def print_welcome_message():
+def print_welcome_message() -> None:
     print ("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
     print ("     @@@@@@@@@@@@        &        Welcome  to  POLUS        &        @@@@@@@@@@@@     ")
     print ("     @@@@@@@@@@@@       &&&       Welcome  to  POLUS       &&&       @@@@@@@@@@@@     ")
@@ -63,7 +63,7 @@ def print_welcome_message():
     print (" ")
     time.sleep(2)
 
-def PrintGBMessage():
+def PrintGBMessage() -> None:
     print ("")
     print ("THANKS FOR USING POLUS")
     print ("*"*81)
@@ -72,7 +72,7 @@ def PrintGBMessage():
     print ("*"*81)
     print (" ")
 
-def print_goodbye_message():
+def print_goodbye_message() -> None:
     print ("")
     print ("*"*81)
     print ("GOODBYE")
@@ -81,7 +81,7 @@ def print_goodbye_message():
     print (" For more details: bienfait.isamura@postgrad.manchester.ac.uk")
     print ("*"*81)
     print (" ")
-def print_help():
+def print_help() -> None:
     print (" ")
     print ("    This code performs various data sampling tasks (from any reference data) into training and validation sets.")
     print ("    Available sampling techniques include:")
@@ -130,10 +130,10 @@ def print_help():
     print ("    For more details: bienfait.isamura@postgrad.manchester.ac.uk")
     print ("")
 
-def print_version():
+def print_version() -> None:
     print ("    SRS version 1.0")
     
-def print_input_details():
+def print_input_details() -> None:
     list_files = check_input_files()
     print ("    File                                   Status")
     print ("    ----                                   ------")
@@ -151,8 +151,8 @@ def print_input_details():
             else:
                 print (f"    {atoms[i-1]}_file                                NOT FOUND")
 
-def print_job_details(system_name,strat_method,tr_set_size,ival_set_size,\
-                      eval_set_size,list_atoms,list_props):
+def print_job_details(system_name: str, strat_method: str, tr_set_size: int, ival_set_size: int,\
+                      eval_set_size: int, list_atoms: list[str], list_props: list[str]) -> None:
     
     print("JOB DETAILS")
     print("-----------")

--- a/src/polus/utils/read_module.py
+++ b/src/polus/utils/read_module.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 
-def check_file(path):
+def check_file(path: str) -> bool:
     """
     This function checks the existence of a file
     
@@ -17,7 +17,7 @@ def check_file(path):
         
     return exist
 
-def get_filesize(filename, unit="bytes"):
+def get_filesize(filename: str, unit: str = "bytes") -> None:
     """
     This function evaluates and returns the size of a file
     
@@ -43,7 +43,7 @@ def get_filesize(filename, unit="bytes"):
         
     return size
 
-def check_property(filename,prop="iqa"):
+def check_property(filename: str, prop: str = "iqa") -> bool:
     """
     This function checks the existence of the data associated with the target physical properties. It basically reads 
     the file's header and locate a column that matches the property's name.
@@ -67,7 +67,7 @@ def check_property(filename,prop="iqa"):
 
     return found
         
-def readfile(filename, prop="iqa"):
+def readfile(filename: str, prop: str = "iqa"):
     """
     This function reads the content of a file and returns many components including the header, the file body, a vector of target property values,
     feature column indices, property column indicie and the indices of the remaining columns (possibly hosting data for other physical properties). 
@@ -132,7 +132,7 @@ def readfile(filename, prop="iqa"):
             
     return header, file_body, prop_vector, features_indices, prop_index, all_prop_indices
 
-def read_job_details():
+def read_job_details() -> tuple[str, str, int, int, int, list[str], list[str], str, str, object]:
     system_name = None
     strat_method = None
     tr_set_size = None
@@ -204,7 +204,7 @@ def read_job_details():
     return result
 
 
-def check_input_files():
+def check_input_files() -> list[bool]:
     #TODO: should take as input the actual input dir
     list_exists = []
     job_detail_file = "JOB_DETAILS.txt"
@@ -228,7 +228,7 @@ def check_input_files():
         list_exists.append(False)
 
     return list_exists
-def SAR_goodbye():
+def SAR_goodbye() -> None:
     print (" ")
     print (" Thanks for using POLUS (Sampling Algorithms for Regression).")
     print (" For more details: bienfait.isamura@postgrad.manchester.ac.uk")

--- a/src/polus/utils/stratifiers.py
+++ b/src/polus/utils/stratifiers.py
@@ -10,7 +10,7 @@ import numpy as np
 import math
 import statistics
 
-def sturges(population):
+def sturges(population: list[object]) -> int:
     population_size   = len(population)
     number_of_bins    = math.ceil(1+math.log(population_size,2))
     
@@ -19,7 +19,7 @@ def sturges(population):
         
     return number_of_bins
 
-def doane(population):
+def doane(population: list[object]) -> int:
     pop_size       = len(population)
     mean           = statistics.mean(population)
     g1_numer       = 0
@@ -44,7 +44,7 @@ def doane(population):
         
     return number_of_bins
 
-def scott(population):
+def scott(population: list[object]) -> int:
     population_size   = len(population)
     std               = statistics.stdev(population)
     bin_width         = 3.49*std/(np.power(population_size,1/3))
@@ -57,7 +57,7 @@ def scott(population):
         
     return number_of_bins
 
-def fd(population):
+def fd(population: list[object]) -> int:
     population_size   = len(population)
     q3, q1            = np.percentile(population, [75 ,25])
     iqr               = q3 - q1
@@ -73,7 +73,7 @@ def fd(population):
         
     return number_of_bins
 
-def rice(population):
+def rice(population: list[object]) -> int:
     population_size   = len(population)
     number_of_bins    = math.ceil(2*np.power(population_size,1/3))
     
@@ -82,7 +82,7 @@ def rice(population):
         
     return number_of_bins
 
-def EpB(population):
+def EpB(population: list[object]) -> int:
     population_size   = len(population)                
     number_of_bins    = math.ceil(np.power(2*population_size,2/5))
     
@@ -91,7 +91,7 @@ def EpB(population):
         
     return number_of_bins    
 
-def get_strat_properties(population,strat):
+def get_strat_properties(population: list[object], strat: str | int) -> tuple[int, None, None, None, None, None, None, None, None]:
     
     # Return number_of_bins, range, IQR, min, max,
     # Std, median, mean, kurtosis

--- a/src/polus/utils/userInputs.py
+++ b/src/polus/utils/userInputs.py
@@ -9,7 +9,7 @@ cwd         = os.getcwd()
 elements    = ["C","H","O","N","P","S","F","Cl"]
 prop_itls   = ["i","q"]
 
-def ReadAtomLabels(input_dir):
+def ReadAtomLabels(input_dir: str) -> list[object]:
     """
     This function reads the atom labels from the input .cvs filenames.
     
@@ -35,7 +35,7 @@ def ReadAtomLabels(input_dir):
 
     return atoms
 
-def GetProps(allProps=False,momentRank=4):
+def GetProps(allProps: bool = False, momentRank: int = 4) -> list[str]:
     """
     This function generates the list of possible target property names.
     
@@ -57,7 +57,7 @@ def GetProps(allProps=False,momentRank=4):
         props = ["iqa"]
     return props
 
-def read_config():
+def read_config() -> tuple[str, list[object], list[object], str, list[int], list[int], list[int], float, float]:
     """
     This function (depricated) used to read the content of a user-supplied configuration file.
     
@@ -96,7 +96,7 @@ def read_config():
     return system_name, atoms, props, method, train, val, test, iqa_filt, q00_filt
 
 
-def read_cmd_args():
+def read_cmd_args() -> tuple[str | None, str | None, list[str] | None, list[str] | None, str | None, str | None, list[int] | None, list[int] | None, list[int] | None, int, str | None]:
     """
     This function (depricated) used to read command line arguments.
     


### PR DESCRIPTION
Some types are too unclear to label. In these cases, either the object type has been used or the type hint has been omitted.

Partially resolves #2.