### PR TITLE
Update README.md to warn users to use the correct Python Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ POLUS performs various tasks, such as:
 - Identification of spatially equivalent atoms based on the distribution of local properties along a dynamic path.
 - Stratification of datasets based on the distribution of both atomic and molecular properties.
 
+
+# Prerequisites
+This project requires Python 3.7.3 through 3.11.7. Versions of Python higher than 3.11.7 or lower than 3.7.3 may result in installation issues with certain packages in requirements.txt.
+
+You can check the version of python you are using with the command:
+```python --version```
+
+
 # Installation
 
 POLUS can be easily installed by following these steps:
@@ -18,8 +26,10 @@ POLUS can be easily installed by following these steps:
 made available the development version called "polus-dev".
 
 2. Move inside the downloaded/cloned folder: ```cd polus-dev```
+   
+3. Double check if you have the correct python version installed (for this codebase).
 
-3. ```pip install .```
+4. ```pip install .```
 
 We recommend that the package be installed in a dedicated virtual environment.
 Assuming the name of the environment is "polus", it is easy to create one following
@@ -35,7 +45,7 @@ OR
 
 2. ```conda activate polus```
 
-
+It's recommended to install this package in a dedicated virtual environment to isolate dependencies, including the required Python version, ensuring they only impact this codebase and don’t interfere with other projects on your system.
 
 # Examples
 


### PR DESCRIPTION
I have updated the README.md to warn the reader that a specific range of python versions only work for this codebase. I have also included the command to check which Python version you are using. I added a reason why a dedicated virtual environment is needed, and also updated this instruction for installation of this codebase.

This is a solution for Issue #10 